### PR TITLE
Add GitHub pages workflow for publishing JSON collections

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,42 @@
+name: GitHub Pages
+
+on:
+  push:
+    # This branch pattern needs to be allowed in the environment
+    # protection rules.
+    tags:
+      - v*
+  workflow_dispatch:
+
+# Sets permissions to allow deployment to GitHub Pages.
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the
+# run in-progress and latest queued. However, do NOT cancel in-progress
+# runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Pages
+        uses: actions/configure-pages@v3
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          # Upload just the JSON collections.
+          path: 'json/'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2


### PR DESCRIPTION
This will publish the JSON collections to GitHub pages when new tags are made or when the workflow is run manually. This will allow controlled releases of the collections in a CDN fronted environment that's appropriate for consumption in our apps at runtime.

The workflow is slightly customized from the static HTML starter workflow suggested by GitHub. It uses an Environment rather than publishing from a git branch. By default the environment will allow deploying from `main`, but it also needs to be allowed to deploy from the `v*` pattern for tags.

I ran this in my forked repo to test it. You can download https://dbnicholson.github.io/endless-key-collections/artist-0001.json, for example. If you look at the HTTP headers, you can glean that it's using Fastly as a CDN with a 10 minute TTL. See [this Actions run](https://github.com/dbnicholson/endless-key-collections/actions/runs/5318227631) triggered by a test `v0.2.1` tag push.