### PR TITLE
Add collection.zip bundle to release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,28 @@
+name: Release
+
+on:
+  push:
+    # This branch pattern needs to be allowed in the environment
+    # protection rules.
+    tags:
+      - v*
+
+jobs:
+  release:
+    name: Create release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install zip
+        run: |
+          apt update
+          apt install -y zip
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Build collections bundle
+        run: ./tools/bundle.sh
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          generate_release_notes: true
+          fail_on_unmatched_files: true
+          files: collections.zip

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+collections.zip

--- a/tools/bundle.sh
+++ b/tools/bundle.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Copyright 2023 Endless OS Foundation LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+set -e
+
+TOOLSDIR=$(dirname "$(realpath "$0")")
+SRCDIR=$(dirname "$TOOLSDIR")
+JSONDIR="$SRCDIR/json"
+OUTPUT="$SRCDIR/collections.zip"
+
+echo "Creating $OUTPUT"
+rm -f "$OUTPUT"
+(cd "$JSONDIR" && zip -v "$OUTPUT" -- *.json)


### PR DESCRIPTION
This will provide stable downloads of the collections file for each release, which is better than taking the generated source tarball and filtering out the JSON collection files.