### PR TITLE
Rename espanol-extras starter pack to spanish-extras

### DIFF
--- a/json/spanish-0001.json
+++ b/json/spanish-0001.json
@@ -59,9 +59,9 @@
     }
   ],
   "metadata": {
-    "title": "espanol",
+    "title": "spanish",
     "subtitle": "0001",
-    "description": "espanol",
+    "description": "spanish",
     "required_gigabytes": 2,
     "tagged_node_ids": [
       {

--- a/json/spanish-extras-0001.json
+++ b/json/spanish-extras-0001.json
@@ -79,9 +79,9 @@
     }
   ],
   "metadata": {
-    "title": "espanol_extras",
+    "title": "spanish_extras",
     "subtitle": "0001",
-    "description": "espanol_extras",
+    "description": "spanish_extras",
     "required_gigabytes": 8,
     "tagged_node_ids": []
   },


### PR DESCRIPTION
This is more consistent with the spanish starter pack. Judging by the metadata, maybe that should have been espanol, but the filename takes precedence over the metadata. Make the spanish metadata consistent with the filename while here.

See: https://github.com/endlessm/endless-key-content-private/issues/103