### PR TITLE
T35103 remove extras content

### DIFF
--- a/json/extras-preload-0001.json
+++ b/json/extras-preload-0001.json
@@ -3,124 +3,186 @@
     {
       "id": "359e048230974c8f80db1a95dc80d544",
       "version": 3,
-      "include_node_ids": []
+      "include_node_ids": [
+        "750713628a7640aeae53caf48ee232d2",
+        "d8fee171f65949e0911ba290f6ad513d",
+        "f8cfc520f846402790d669ce11d7b436"
+      ]
     },
     {
       "id": "ee52db4a62a94e9683599af8782f2d03",
       "version": 3,
-      "include_node_ids": []
+      "include_node_ids": [
+        "ee52db4a62a94e9683599af8782f2d03"
+      ]
     },
     {
       "id": "8fa678af1dd05329bf3218c549b84996",
       "version": 1,
-      "include_node_ids": []
+      "include_node_ids": [
+        "8fa678af1dd05329bf3218c549b84996"
+      ]
     },
     {
       "id": "b6a8886278aa45a3a40c2e0ae5358115",
       "version": 1,
-      "include_node_ids": []
+      "include_node_ids": [
+        "b6a8886278aa45a3a40c2e0ae5358115"
+      ]
     },
     {
       "id": "30c71c99c42c57d181e8aeafd2e15e5f",
       "version": 17,
-      "include_node_ids": []
+      "include_node_ids": [
+        "30c71c99c42c57d181e8aeafd2e15e5f"
+      ]
     },
     {
       "id": "b06dd546e8ba4b44bf921862c9948ffe",
       "version": 33,
-      "include_node_ids": []
+      "include_node_ids": [
+        "b06dd546e8ba4b44bf921862c9948ffe"
+      ]
     },
     {
       "id": "608fd926be60462aba2feccba6c050c9",
       "version": 6,
-      "include_node_ids": []
+      "include_node_ids": [
+        "608fd926be60462aba2feccba6c050c9"
+      ]
     },
     {
       "id": "08897e003ea9489eb3d86fc94ba08c21",
       "version": 20,
-      "include_node_ids": []
+      "include_node_ids": [
+        "08897e003ea9489eb3d86fc94ba08c21"
+      ]
     },
     {
       "id": "4b2f3f35debe4fbe96b77558a3364675",
       "version": 1,
-      "include_node_ids": []
+      "include_node_ids": [
+        "4b2f3f35debe4fbe96b77558a3364675"
+      ]
     },
     {
       "id": "217c7164c2974a4da9877a20ae38b98e",
       "version": 8,
-      "include_node_ids": []
+      "include_node_ids": [
+        "217c7164c2974a4da9877a20ae38b98e"
+      ]
     },
     {
       "id": "ed519e3b798147569b46cb550dbfc373",
       "version": 1,
-      "include_node_ids": []
+      "include_node_ids": [
+        "046e82e3fe5a44f193ceae09aabc7d79"
+      ]
     },
     {
       "id": "4968191fba07548c9592fc174a70b5d6",
       "version": 4,
-      "include_node_ids": []
+      "include_node_ids": [
+        "4968191fba07548c9592fc174a70b5d6"
+      ]
     },
     {
       "id": "bcc6e12a0ddf4a17a8b600c6b880e3ed",
       "version": 10,
-      "include_node_ids": []
+      "include_node_ids": [
+        "bcc6e12a0ddf4a17a8b600c6b880e3ed"
+      ]
     },
     {
       "id": "bbb4ea407a3c450cb18cbaa76f2d75cd",
       "version": 7,
-      "include_node_ids": []
+      "include_node_ids": [
+        "879d5bc396fb4bd28473983795a0ec49",
+        "51966da0c3ed43c78a39f5d9efa0f519",
+        "d0e9a8b1d7934329b46b48549897e10f",
+        "c386891717d64fa69c4321fb4a209402",
+        "c61ca0f85dce4692a24b3ede5b4d514a",
+        "2576b1ba6f3a44cb804e99d5dd38877a",
+        "48e971693cd447e9b550e0635a621311",
+        "db95d636501f42a3b4969e5033ec9b25"
+      ]
     },
     {
       "id": "bf36d8e7e1ee56b194fe52cafbfd9db3",
       "version": 3,
-      "include_node_ids": []
+      "include_node_ids": [
+        "3ed168b79e605d41aa97c1a84c4d84a2",
+        "b94aa326329b5c40b605b791182d2c7d",
+        "6bfe72c2a4765f6699a6d5b484932849"
+      ]
     },
     {
       "id": "2b43973f53f1538bad5ece63ad847606",
       "version": 6,
-      "include_node_ids": []
+      "include_node_ids": [
+        "2b43973f53f1538bad5ece63ad847606"
+      ]
     },
     {
       "id": "0418cc231e9c5513af0fff9f227f7172",
       "version": 5,
-      "include_node_ids": []
+      "include_node_ids": [
+        "476e8755df025fb2a5c996caf79cb59e"
+      ]
     },
     {
       "id": "efcc464be5a85ba5a58d1636b00313fc",
       "version": 9,
-      "include_node_ids": []
+      "include_node_ids": [
+        "efcc464be5a85ba5a58d1636b00313fc"
+      ]
     },
     {
       "id": "a8e6591f1afa426d859318a0a29d1237",
       "version": 4,
-      "include_node_ids": []
+      "include_node_ids": [
+        "a8e6591f1afa426d859318a0a29d1237"
+      ]
     },
     {
       "id": "74f36493bb475b62935fa8705ed59fed",
       "version": 3,
-      "include_node_ids": []
+      "include_node_ids": [
+        "eaef8bc341f8545c9c27a7d6f1b8cbf4",
+        "2dd958c56112576383612e4a1497056b"
+      ]
     },
     {
       "id": "4e413158eac55422a5343af9fcfa8d59",
       "version": 8,
-      "include_node_ids": []
+      "include_node_ids": [
+        "4e413158eac55422a5343af9fcfa8d59"
+      ]
     },
     {
       "id": "eb4373b5da054c07879d0c969dc1976a",
       "version": 7,
-      "include_node_ids": []
+      "include_node_ids": [
+        "eb4373b5da054c07879d0c969dc1976a"
+      ]
     }
   ],
   "metadata": {
-    "title": "Extras",
+    "title": "Extras_preload",
     "subtitle": "0001",
-    "description": "extras",
-    "required_gigabytes": 1,
+    "description": "extras_preload",
+    "required_gigabytes": 12,
     "tagged_node_ids": [
       {
         "node_id": "359e048230974c8f80db1a95dc80d544",
         "tags": [
           "featured-channel"
+        ]
+      },
+      {
+        "node_id": "750713628a7640aeae53caf48ee232d2",
+        "tags": [
+          "curious"
         ]
       },
       {

--- a/json/spanish-extras-0001.json
+++ b/json/spanish-extras-0001.json
@@ -3,83 +3,54 @@
     {
       "id": "fed29d60e4d84a1e8dcfc781d920b40e",
       "version": 4,
-      "include_node_ids": [
-        "904e95f813f5458fb36d3e847cf3b55e",
-        "9006353b891949b0b91df0316275dbda",
-        "edbe2890609d49a6b0cda3f2b1767253",
-        "89fe2f86ee3f4fbaa7fb2bf9bd56d088"
-      ]
+      "include_node_ids": []
     },
     {
       "id": "c984c3f6cec55ecc997769213e5a855d",
       "version": 6,
-      "include_node_ids": [
-        "fd12ab1c5aa25551b5e4094285aa4c30",
-        "928a270898835b9b998df98f280faa4a",
-        "d982349bbb1f5f008388bf4a049e63eb"
-      ]
+      "include_node_ids": []
     },
     {
       "id": "1c98e92b8c2f536796960bed8d137a25",
       "version": 1,
-      "include_node_ids": [
-        "42dacef4d34157bca61bb3e422211e31"
-      ]
+      "include_node_ids": []
     },
     {
       "id": "07cd1633691b4473b6fda08caf826253",
       "version": 1,
-      "include_node_ids": [
-        "ce9094a57cef54dda450077f2ca93d70",
-        "9d209180cefb5eab8a4d37a486a3a700",
-        "09c033218760528a90e20749ab57736b",
-        "c4c6cdca4e32581aac166cfa82a0b782",
-        "aa0129e1f3d75aae9d3e910407310142"
-      ]
+      "include_node_ids": []
     },
     {
       "id": "f446655247a95c0aa94ca9fa4d66783b",
       "version": 1,
-      "include_node_ids": [
-        "f90ac1f9bbb2587f9dfc1b87b803abdd",
-        "27a940afa61454e880b3f4fe53ccbe9d"
-      ]
+      "include_node_ids": []
     },
     {
       "id": "c4ad70f67dff57738591086e466f9afc",
       "version": 1,
-      "include_node_ids": [
-        "c4ad70f67dff57738591086e466f9afc"
-      ]
+      "include_node_ids": []
     },
     {
       "id": "30c71c99c42c57d181e8aeafd2e15e5f",
       "version": 17,
-      "include_node_ids": [
-        "9d57d2f14c1d571c80204a7af9747942",
-        "e2658af1fa6a57c9980b923ec0723cb0"
-      ]
+      "include_node_ids": []
     },
     {
       "id": "b06dd546e8ba4b44bf921862c9948ffe",
       "version": 34,
-      "include_node_ids": [
-        "b06dd546e8ba4b44bf921862c9948ffe"
-      ]
+      "include_node_ids": []
     },
     {
       "id": "956d818272395cf68ad160df698dacc3",
       "version": 2,
-      "include_node_ids": [
-        "956d818272395cf68ad160df698dacc3"
-      ]
+      "include_node_ids": []
     }
   ],
   "metadata": {
     "title": "spanish_extras",
     "subtitle": "0001",
     "description": "spanish_extras",
-    "required_gigabytes": 8,
+    "required_gigabytes": 1,
     "tagged_node_ids": []
   },
   "channel_list_hash": ""


### PR DESCRIPTION
These changes differentiate between `spanish-extras-0001.json` and `spanish-extras-preload-0001.json`, as well as `extras-0001.json` and (newly added) `extras-preload-0001.json`. The purpose here is to tell the image builder "these channels are important, so we want to include their metadata, but we don't want to include any content from them." The `-preload` collections are the variants for large images where we _do_ want to include content from these extra channels.

My understanding is that has always _been_ the purpose of these collections, but I'd appreciate an additional sanity check :)

(Incidentally, I'm not a fan of the extras / extras-preload naming convention here, but I also want to limit the number of changes that need to happen in endless-image-config).

https://phabricator.endlessm.com/T35103